### PR TITLE
update TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This uses the new setup recommended at https://github.com/JuliaRegistries/TagBot. The old version based on cron jobs was disabled:
> This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days.

That's the reason why `v0.3` is available in the Julia registry but GitHub shows only `v0.2`:
![image](https://user-images.githubusercontent.com/12693098/124229418-dcc6b580-db0d-11eb-9de3-15fe84049113.png)
