### PR TITLE
Bump compat on PrettyTables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinuxPerf"
 uuid = "b4c46c6c-4fb0-484d-a11a-41bc3392d094"
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
@@ -9,5 +9,5 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 Formatting = "0.4"
-PrettyTables = "0.9, 1"
+PrettyTables = "0.9, 1, 2"
 julia = "1"


### PR DESCRIPTION
Seems to work without issue:
```julia
julia> @pstats "(cpu-cycles,task-clock),(instructions,branch-instructions,branch-misses), (L1-dcache-load-misses, L1-dcache-loads, cache-misses, cache-references)" begin
         foreachf(add_vec_fb, 10, vectors1, 3, 1, 2)
       end
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ cpu-cycles               9.18e+08  100.0%  #  4.4 cycles per ns
└ task-clock               2.08e+08  100.0%  # 207.5 ms
┌ instructions             1.55e+09  100.0%  #  1.7 insns per cycle
│ branch-instructions      3.18e+08  100.0%  # 20.5% of insns
└ branch-misses            7.23e+06  100.0%  #  2.3% of branch insns
┌ L1-dcache-load-misses    1.28e+07  100.0%  #  2.9% of dcache loads
│ L1-dcache-loads          4.40e+08  100.0%
│ cache-misses             2.78e+06  100.0%  # 28.2% of cache refs
└ cache-references         9.86e+06  100.0%
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

(lvdev) pkg> st -m LinuxPerf PrettyTables
Status `~/Documents/progwork/julia/env/lvdev/Manifest.toml`
  [b4c46c6c] LinuxPerf v0.3.4 `~/.julia/dev/LinuxPerf`
  [08abe8d2] PrettyTables v2.1.2

julia> Base.JLOptions().depwarn
2
```