### PR TITLE
In the expression returned by the `parse_pstats_options` function, expand the output of `parse_groups`

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -553,7 +553,7 @@ end
 
 function parse_pstats_options(opts)
     # default events
-    events = :(parse_groups("
+    events = :(LinuxPerf.parse_groups("
         (cpu-cycles, stalled-cycles-frontend, stalled-cycles-backend),
         (instructions, branch-instructions, branch-misses),
         (task-clock, context-switches, cpu-migrations, page-faults)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -553,7 +553,7 @@ end
 
 function parse_pstats_options(opts)
     # default events
-    events = :(LinuxPerf.parse_groups("
+    events = :($parse_groups("
         (cpu-cycles, stalled-cycles-frontend, stalled-cycles-backend),
         (instructions, branch-instructions, branch-misses),
         (task-clock, context-switches, cpu-migrations, page-faults)


### PR DESCRIPTION
Motivation: I want to use `parse_pstats_options` outside of LinuxPerf.jl, so we need to change `parse_groups` to `LinuxPerf.parse_groups` to make sure it works even if `parse_groups` is not in scope.

Needed for https://github.com/JuliaCI/BenchmarkTools.jl/pull/325

---

Note: `parse_pstats_options` is internal to LinuxPerf.jl, so downstream users of `parse_pstats_options` (like myself) should set the `[compat]` for LinuxPerf.jl to the exact `major.minor.patch` version.