### PR TITLE
Expand output of `parse_groups` in `parse_pstats_options`, fixes pr #32

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -565,7 +565,7 @@ function parse_pstats_options(opts)
     threads = true
     for (i, opt) in enumerate(opts)
         if i == 1 && !(opt isa Expr && opt.head == :(=))
-            events = :(parse_groups($(esc(opt))))
+            events = :($parse_groups($(esc(opt))))
         elseif opt isa Expr && opt.head == :(=)
             key, val = opt.args
             val = esc(val)


### PR DESCRIPTION
In #32, only the first call to parse_groups was changed. I assume this was an oversight as it's not obvious to me why the behaviour would differ. 