### PR TITLE
Add warning for `perf_event_paranoid >= 3`

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -289,8 +289,12 @@ mutable struct EventGroup
                     end
                     continue
                 else
-                    if errno == Libc.EACCES && !userspace_only
-                        @warn("try to adjust /proc/sys/kernel/perf_event_paranoid to a value <= 1 or use user-space only events")
+                    if errno == Libc.EACCES
+                        if !userspace_only
+                            @warn("try to adjust /proc/sys/kernel/perf_event_paranoid to a value <= 1 or use user-space only events")
+                        else
+                            @warn("try to adjust /proc/sys/kernel/perf_event_paranoid to a value <= 2 or run with the CAP_PERFMON capability")
+                        end
                     end
                     error("perf_event_open error : $(Libc.strerror(errno))")
                 end


### PR DESCRIPTION
Paranoia settings this high don't allow even user-level perf monitoring of your own process.

That documentation can be hard to find online so this adds a warning to nudge the user in the right direction:
```julia
julia> bench = make_bench([LinuxPerf.EventType(:hw, :instructions)])
┌ Warning: try to adjust /proc/sys/kernel/perf_event_paranoid to a value <= 2 or run with the CAP_SYS_ADMIN capability
└ @ LinuxPerf ~/.julia/dev/LinuxPerf/src/LinuxPerf.jl:301
ERROR: perf_event_open error : Permission denied
```