### PR TITLE
Fix syscall numbers for non-x86_64 architectures

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -493,8 +493,10 @@ Base.close(b::PerfBenchThreaded) = foreach(close, b.data)
 
 function make_bench_threaded(groups; threads = true)
     data = PerfBench[]
+    warn_unsupported = true
     for tid in (threads ? alltids() : zero(getpid()))
-        push!(data, PerfBench(tid, [EventGroup(g, pid = tid, userspace_only = false) for g in groups]))
+        push!(data, PerfBench(tid, [EventGroup(g; pid = tid, userspace_only = false, warn_unsupported) for g in groups]))
+        warn_unsupported = false # First tid's events will already have issued warnings
     end
     return PerfBenchThreaded(data)
 end


### PR DESCRIPTION
This gets LinuxPerf.jl working for me on `aarch64-linux`:

```julia
julia> @pstats nothing
┌ Warning: LinuxPerf.EventTypeExt(hw:branches, false, 0x0000000000000006) not supported, skipping
└ @ LinuxPerf ~/.julia/dev/LinuxPerf/src/LinuxPerf.jl:299
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ cpu-cycles               2.50e+02  100.0%  #  0.0 cycles per ns
│ stalled-cycles-frontend  2.18e+02  100.0%  # 87.2% of cycles
└ stalled-cycles-backend   2.30e+01  100.0%  #  9.2% of cycles
┌ instructions             1.80e+01  100.0%  #  0.1 insns per cycle
└ branch-misses            2.00e+00  100.0%
┌ task-clock               1.64e+05  100.0%  # 164.5 μs
│ context-switches         0.00e+00  100.0%
│ cpu-migrations           0.00e+00  100.0%
└ page-faults              0.00e+00  100.0%
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

Fixes https://github.com/JuliaPerf/LinuxPerf.jl/issues/39

(note: the warning is due to a bug in that hasn't been fixed yet in my kernel:
https://patchwork.kernel.org/project/linux-arm-kernel/patch/20230403091547.441550-1-peternewman@google.com/)