### PR TITLE
Don't leak `PerfBench` in `@measure`

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -12,7 +12,9 @@ macro measure(expr, args...)
     esc(quote
         local bench
         _, bench = $LinuxPerf.@measured($expr, $(args...))
-        $counters(bench)
+        local counts = $counters(bench)
+        $close(bench)
+        counts
     end)
 end
 macro measured(expr, events = reasonable_defaults)


### PR DESCRIPTION
It's important not to leak these perf events, due to limited PMU resources on the system.

Without this fix, running the two README examples back-to-back on my system leads to:
```
┌ Warning: Some events are not measured
└ @ LinuxPerf ~/.julia/dev/LinuxPerf/src/LinuxPerf.jl:892
...
┌ instructions                   NA    0.0%
└ branch-misses                  NA    0.0%
```