### PR TITLE
Add fastpath for prctl and add fallback instead of erroring

### DIFF
--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -350,7 +350,7 @@ end
 const PR_TASK_PERF_EVENTS_DISABLE = Cint(31)
 const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
 
-@inline function fast_prctl(op)
+@inline function prctl(op)
     if SYS_prctl == -1
         res = ccall(:prctl, Cint, (Cint, Cint...), op)
         return Base.systemerror(:prctl, res < 0)
@@ -369,8 +369,8 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
     end
 end
 
-enable_all!() = fast_prctl(PR_TASK_PERF_EVENTS_ENABLE)
-disable_all!() = fast_prctl(PR_TASK_PERF_EVENTS_DISABLE)
+enable_all!() = prctl(PR_TASK_PERF_EVENTS_ENABLE)
+disable_all!() = prctl(PR_TASK_PERF_EVENTS_DISABLE)
 
 const PERF_EVENT_IOC_ENABLE =  UInt64(0x2400)
 const PERF_EVENT_IOC_DISABLE = UInt64(0x2401)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -359,6 +359,7 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
         ret i32 %a
         """, Int32, Tuple{Int64, Int32}, SYS_prctl, op)
     else
+        # syscall is lower overhead than calling libc's prctl
         ccall(:syscall, Cint, (Clong, Clong...), SYS_prctl, op)
     end
     Base.systemerror(:prctl, res < 0)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -362,12 +362,8 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
     Base.systemerror(:prctl, res < 0)
 end
 
-function enable_all!()
-    fast_prctl(PR_TASK_PERF_EVENTS_ENABLE)
-end
-function disable_all!()
-    fast_prctl(PR_TASK_PERF_EVENTS_DISABLE)
-end
+enable_all!() = fast_prctl(PR_TASK_PERF_EVENTS_ENABLE)
+disable_all!() = fast_prctl(PR_TASK_PERF_EVENTS_DISABLE)
 
 const PERF_EVENT_IOC_ENABLE =  UInt64(0x2400)
 const PERF_EVENT_IOC_DISABLE = UInt64(0x2401)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -352,7 +352,7 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
 
 @inline function fast_prctl(op)
     if SYS_prctl == -1
-        res = ccall(:prctl, Cint, (Cint,), op)
+        res = ccall(:prctl, Cint, (Cint, Cint...), op)
     else
         res = Base.llvmcall("""
         %a = call i32 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 %0, i32 %1)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -352,14 +352,15 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
 
 @inline function fast_prctl(op)
     if SYS_prctl == -1
-        res = ccall(:prctl, Cint, (Cint...), op)
+        res = ccall(:prctl, Cint, (Cint,), op)
     else
         res = Base.llvmcall("""
-        %a = call i32 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 $SYS_prctl, i32 $op)
+        %a = call i32 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 %0, i32 %1)
         ret i32 %a
-        """, Int32, Tuple{})
+        """, Int32, Tuple{Int64, Int32}, SYS_prctl, op)
     end
     Base.systemerror(:prctl, res < 0)
+end
 
 function enable_all!()
     fast_prctl(PR_TASK_PERF_EVENTS_ENABLE)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -354,8 +354,10 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
     if SYS_prctl == -1
         res = ccall(:prctl, Cint, (Cint...), op)
     else
-        # syscall is lower overhead than calling libc's prctl
-        res = ccall(:syscall, Cint, (Clong, Clong...), SYS_prctl, op)
+        res = Base.llvmcall("""
+        %a = call i32 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 $SYS_prctl, i32 $op)
+        ret i32 %a
+        """, Int32, Tuple{})
     end
     Base.systemerror(:prctl, res < 0)
 

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -353,7 +353,7 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
 @inline function fast_prctl(op)
     res = if SYS_prctl == -1
         ccall(:prctl, Cint, (Cint, Cint...), op)
-    elseif Sys.ARCH == :86_64
+    elseif Sys.ARCH == :x86_64
         Base.llvmcall("""
         %a = call i32 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 %0, i32 %1)
         ret i32 %a


### PR DESCRIPTION
`fast_prctl` compiles down to just a single llvm call on x86_64 for me.