### PR TITLE
Fix-up behavior for empty `PerfGroup`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using LinuxPerf
 using Test
 
-using LinuxPerf: make_bench, enable!, disable!, reset!, reasonable_defaults, counters, EventType, EventTypeExt, parse_groups, enable_all!, disable_all!
+using LinuxPerf: make_bench, enable!, disable!, reset!, reasonable_defaults, counters, EventGroup, EventType, EventTypeExt, parse_groups, enable_all!, disable_all!
 
 @testset "LinuxPerf" begin
 
@@ -126,6 +126,14 @@ end
     @test LinuxPerf._addcommas(1234) == "1,234"
     @test LinuxPerf._addcommas(12345) == "12,345"
     @test LinuxPerf._addcommas(typemin(Int64)) == "-9,223,372,036,854,775,808"
+end
+
+@testset "empty EventGroup" begin
+    # Creating an empty EventGroup should be a no-op (and not error)
+    g = EventGroup(EventType[])
+    @test length(g.fds) == 0
+    @test g.leader_fd == -1
+    close(g) # also a no-op
 end
 
 end


### PR DESCRIPTION
For machines that don't have perf properly configured, it's common to end up with an empty PerfGroup that has an invalid `leader_fd`. This commit adds the appropriate guards to make sure that doesn't error excessively.

On my WSL2 setup, this takes the test suite from:
```
Test Summary:      | Pass  Error  Total  Time
LinuxPerf          |   31      4     35  4.6s
  simple benchmark |           2      2  2.6s
  @measure         |           1      1  0.1s
  Parser           |   24            24  0.3s
  @pstats          |    1      1      2  1.5s
  _addcommas       |    6             6  0.0s
ERROR: LoadError: Some tests did not pass: 31 passed, 0 failed, 4 errored, 0 broken.
```

to:
```
Test Summary: | Pass  Total  Time
LinuxPerf     |   37     37  3.1s
```