### PR TITLE
Fix-up i686/armv7 support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,54 @@
 steps:
-  - label: "Julia v1.6"
+  - label: "Julia v1.6 (x86-64)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1.6"
+          arch: "x86_64"
       - JuliaCI/julia-test#v1:
     agents:
       queue: "juliaecosystem"
       sandbox.jl: "true"
       os: "linux"
       arch: "x86_64"
+    timeout_in_minutes: 60
+  - label: "Julia v1.6 (i686)"
+    plugins:
+      - JuliaCI/julia:
+          version: "1"
+      - staticfloat/sandbox#v1:
+         rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.44/agent_linux.i686.tar.gz"
+         rootfs_treehash: "c0e2d7ef8f233d978c15e61734f0dfa25aba7536"
+      - JuliaCI/julia:
+          version: "1.6"
+          arch: "i686"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "x86_64"
+    timeout_in_minutes: 60
+  - label: "Julia v1.6 (AArch64)"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.6"
+          arch: "aarch64"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "aarch64"
+    timeout_in_minutes: 60
+  - label: "Julia v1.6 (ARMv7)"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.6"
+          arch: "armv7l"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "armv7l"
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,39 +31,3 @@ steps:
       os: "linux"
       arch: "x86_64"
     timeout_in_minutes: 60
-  - label: "Julia v1.6 (AArch64)"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.6"
-          arch: "aarch64"
-      - JuliaCI/julia-test#v1:
-    agents:
-      queue: "juliaecosystem"
-      sandbox.jl: "true"
-      os: "linux"
-      arch: "aarch64"
-    timeout_in_minutes: 60
-  - label: "Julia v1.6 (ARMv7)"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.6"
-          arch: "armv7l"
-      - JuliaCI/julia-test#v1:
-    agents:
-      queue: "juliaecosystem"
-      sandbox.jl: "true"
-      os: "linux"
-      arch: "armv7l"
-    timeout_in_minutes: 60
-  - label: "Julia v1.10 (PPC64le)"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-          arch: "powerpc64le"
-      - JuliaCI/julia-test#v1:
-    agents:
-      queue: "juliaecosystem"
-      sandbox.jl: "true"
-      os: "linux"
-      arch: "powerpc64le"
-    timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,10 +14,13 @@ steps:
   - label: "Julia v1.6 (i686)"
     plugins:
       - JuliaCI/julia:
-          version: "1"
+          version: "1.6"
       - staticfloat/sandbox#v1:
          rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.44/agent_linux.i686.tar.gz"
          rootfs_treehash: "c0e2d7ef8f233d978c15e61734f0dfa25aba7536"
+         workspaces:
+            - "/cache:/cache"
+      # Once inside the sandbox, install a different version of Julia to run our tests
       - JuliaCI/julia:
           version: "1.6"
           arch: "i686"
@@ -51,4 +54,16 @@ steps:
       sandbox.jl: "true"
       os: "linux"
       arch: "armv7l"
+    timeout_in_minutes: 60
+  - label: "Julia v1.10 (PPC64le)"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+          arch: "powerpc64le"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "powerpc64le"
     timeout_in_minutes: 60

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -360,9 +360,17 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
         res = Base.llvmcall("""%val = call i64 asm sideeffect "syscall", "={rax},{rax},{rdi},~{rcx},~{r11},~{memory}"(i64 %0, i64 %1)
                                ret i64 %val""", Int64, Tuple{Int64, Int64}, SYS_prctl, Int64(op))
         return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
+    elseif Sys.ARCH == :i686
+        res = Base.llvmcall("""%val = call i32 asm sideeffect "int \$\$0x80", "={eax},{eax},{ebx},~{memory}"(i32 %0, i32 %1)
+                               ret i32 %val""", Int32, Tuple{Int32, Int32}, SYS_prctl, Int32(op))
+        return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
     elseif Sys.ARCH == :aarch64
         res = Base.llvmcall("""%val = call i64 asm sideeffect "svc #0", "={x0},{x8},{x0},~{memory}"(i64 %0, i64 %1)
                                ret i64 %val""", Int64, Tuple{Int64, Int64}, SYS_prctl, Int64(op))
+        return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
+    elseif Sys.ARCH == :arm
+        res = Base.llvmcall("""%val = call i32 asm sideeffect "swi 0", "={r0},{r7},{r0},~{memory}"(i32 %0, i32 %1)
+                               ret i32 %val""", Int32, Tuple{Int32, Int32}, SYS_prctl, Int32(op))
         return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
     else
         # syscall is lower overhead than calling libc's prctl

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -165,6 +165,8 @@ elseif Sys.ARCH === :aarch64
     Clong(241)
 elseif Sys.ARCH === :arm
     Clong(364)
+elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
+    Clong(319)
 else
     Clong(-1) # sentinel for unknown syscall ID
 end
@@ -346,6 +348,8 @@ elseif Sys.ARCH === :aarch64
     Clong(167)
 elseif Sys.ARCH === :arm
     Clong(172)
+elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
+    Clong(171)
 else
     Clong(-1) # sentinel for unknown syscall ID
 end

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -179,7 +179,7 @@ function perf_event_open(attr::perf_event_attr, pid, cpu, leader_fd, flags)
         # Have to do a manual conversion, since the ABI is a vararg call
         ptr = Base.unsafe_convert(Ptr{Cvoid}, Base.cconvert(Ptr{Cvoid}, r_attr))
         fd = ccall(:syscall, Cint, (Clong, Clong...), SYS_perf_event_open,
-                   ptr, pid, cpu, leader_fd, flags)
+                   reinterpret(Clong, ptr), pid, cpu, leader_fd, flags)
     end
     return fd
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,11 +120,11 @@ end
 end
 
 @testset "_addcommas" begin
-    @test LinuxPerf._addcommas(1) == "1"
-    @test LinuxPerf._addcommas(12) == "12"
-    @test LinuxPerf._addcommas(123) == "123"
-    @test LinuxPerf._addcommas(1234) == "1,234"
-    @test LinuxPerf._addcommas(12345) == "12,345"
+    @test LinuxPerf._addcommas(Int64(1)) == "1"
+    @test LinuxPerf._addcommas(Int64(12)) == "12"
+    @test LinuxPerf._addcommas(Int64(123)) == "123"
+    @test LinuxPerf._addcommas(Int64(1234)) == "1,234"
+    @test LinuxPerf._addcommas(Int64(12345)) == "12,345"
     @test LinuxPerf._addcommas(typemin(Int64)) == "-9,223,372,036,854,775,808"
 end
 


### PR DESCRIPTION
This gets 32-bit working properly (finally), and brings us down to ~5-6 instructions of overhead on x86 and armv7:
```julia
julia> println(Sys.ARCH); @pstats "(instructions,branch-instructions,branch-misses)" nothing
arm
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ instructions             6.00e+00  100.0%
│ branch-instructions      1.00e+00  100.0%  # 16.7% of insns
└ branch-misses            0.00e+00  100.0%  #  0.0% of branch insns
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
```julia
julia> println(Sys.ARCH); @pstats "(instructions,branch-instructions,branch-misses)" nothing
i686
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ instructions             5.00e+00  100.0%
│ branch-instructions      2.00e+00  100.0%  # 40.0% of insns
└ branch-misses            1.00e+00  100.0%  # 50.0% of branch insns
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```