### PR TITLE
Remove `@noinline` for Julia 1.6 / 1.7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,18 @@ steps:
       os: "linux"
       arch: "x86_64"
     timeout_in_minutes: 60
+  - label: "Julia v1.10 (x86-64)"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+          arch: "x86_64"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "x86_64"
+    timeout_in_minutes: 60
   - label: "Julia v1.6 (i686)"
     plugins:
       - JuliaCI/julia:
@@ -23,6 +35,26 @@ steps:
       # Once inside the sandbox, install a different version of Julia to run our tests
       - JuliaCI/julia:
           version: "1.6"
+          arch: "i686"
+      - JuliaCI/julia-test#v1:
+    agents:
+      queue: "juliaecosystem"
+      sandbox.jl: "true"
+      os: "linux"
+      arch: "x86_64"
+    timeout_in_minutes: 60
+  - label: "Julia v1.10 (i686)"
+    plugins:
+      - JuliaCI/julia:
+          version: "1.10"
+      - staticfloat/sandbox#v1:
+         rootfs_url: "https://github.com/JuliaCI/rootfs-images/releases/download/v5.44/agent_linux.i686.tar.gz"
+         rootfs_treehash: "c0e2d7ef8f233d978c15e61734f0dfa25aba7536"
+         workspaces:
+            - "/cache:/cache"
+      # Once inside the sandbox, install a different version of Julia to run our tests
+      - JuliaCI/julia:
+          version: "1.10"
           arch: "i686"
       - JuliaCI/julia-test#v1:
     agents:

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -1146,7 +1146,7 @@ macro pstats(args...)
                     Base.donotdelete(val)
                     stats = Stats(bench)
                 else
-                    stats = (@noinline rand()) < 0 ? val : Stats(bench)
+                    stats = rand() < 0 ? val : Stats(bench)
                 end
                 return stats::Stats
             catch


### PR DESCRIPTION
Apparently call-site `@noinline` support was added in 1.8, which ironically was also when `Base.donotdelete` was added.