### PR TITLE
Support riscv64

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinuxPerf"
 uuid = "b4c46c6c-4fb0-484d-a11a-41bc3392d094"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -167,6 +167,9 @@ elseif Sys.ARCH === :arm
     Clong(364)
 elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
     Clong(319)
+elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
+    # See syscalls table at https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
+    Clong(241)
 else
     Clong(-1) # sentinel for unknown syscall ID
 end
@@ -350,6 +353,9 @@ elseif Sys.ARCH === :arm
     Clong(172)
 elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
     Clong(171)
+elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
+    # See syscalls table at https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
+    Clong(167)
 else
     Clong(-1) # sentinel for unknown syscall ID
 end

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -157,28 +157,29 @@ function Base.show(io::IO, e::EventType)
     end
 end
 
-# To support a new architecture, look for the code corresponding to the `perf_event_open`
-# syscall in https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html
-const SYS_perf_event_open = if Sys.ARCH === :x86_64
+# To support a new architecture, look for the codes corresponding to the
+# `perf_event_open` and `prctl` syscalls in
+# https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html
+const SYS_perf_event_open, SYS_prctl = if Sys.ARCH === :x86_64
     # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_64.tbl
-    Clong(298)
+    Clong(298), Clong(157)
 elseif Sys.ARCH === :i686
     # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_32.tbl
-    Clong(336)
+    Clong(336), Clong(172)
 elseif Sys.ARCH === :aarch64
-    # See also https://arm64.syscall.sh/
-    Clong(241)
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/scripts/syscall.tbl
+    Clong(241), Clong(167)
 elseif Sys.ARCH === :arm
     # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/arm/tools/syscall.tbl
-    Clong(364)
+    Clong(364), Clong(172)
 elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
     # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/powerpc/kernel/syscalls/syscall.tbl
-    Clong(319)
+    Clong(319), Clong(171)
 elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
-    # See also https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
-    Clong(241)
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/scripts/syscall.tbl
+    Clong(241), Clong(167)
 else
-    Clong(-1) # sentinel for unknown syscall ID
+    Clong(-1), Clong(-1) # sentinel for unknown syscall ID
 end
 
 """
@@ -350,29 +351,6 @@ function Base.show(io::IO, g::EventGroup)
     print(io, "\t", g.event_types[end], ")")
 end
 
-# To support a new architecture, look for the code corresponding to the `prctl` syscall in
-# https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html
-const SYS_prctl = if Sys.ARCH === :x86_64
-    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_64.tbl
-    Clong(157)
-elseif Sys.ARCH === :i686
-    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_32.tbl
-    Clong(172)
-elseif Sys.ARCH === :aarch64
-    # See also https://arm64.syscall.sh/
-    Clong(167)
-elseif Sys.ARCH === :arm
-    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/arm/tools/syscall.tbl
-    Clong(172)
-elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
-    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/powerpc/kernel/syscalls/syscall.tbl
-    Clong(171)
-elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
-    # See also https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
-    Clong(167)
-else
-    Clong(-1) # sentinel for unknown syscall ID
-end
 const PR_TASK_PERF_EVENTS_DISABLE = Cint(31)
 const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
 

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -374,6 +374,10 @@ const PR_TASK_PERF_EVENTS_ENABLE = Cint(32)
         res = Base.llvmcall("""%val = call i32 asm sideeffect "swi 0", "={r0},{r7},{r0},~{memory}"(i32 %0, i32 %1)
                                ret i32 %val""", Int32, Tuple{Int32, Int32}, SYS_prctl, Int32(op))
         return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
+    elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
+        res = Base.llvmcall("""%val = call i64 asm sideeffect "ecall", "={a0},{a7},{a0},~{memory}"(i64 %0, i64 %1)
+                               ret i64 %val""", Int64, Tuple{Int64, Int64}, SYS_prctl, Int64(op))
+        return (res >= 0) ? nothing : throw(Base.SystemError("prctl", -res, nothing))
     else
         # syscall is lower overhead than calling libc's prctl
         res = ccall(:syscall, Cint, (Clong, Clong...), SYS_prctl, op)

--- a/src/LinuxPerf.jl
+++ b/src/LinuxPerf.jl
@@ -157,18 +157,25 @@ function Base.show(io::IO, e::EventType)
     end
 end
 
+# To support a new architecture, look for the code corresponding to the `perf_event_open`
+# syscall in https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html
 const SYS_perf_event_open = if Sys.ARCH === :x86_64
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_64.tbl
     Clong(298)
 elseif Sys.ARCH === :i686
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_32.tbl
     Clong(336)
 elseif Sys.ARCH === :aarch64
+    # See also https://arm64.syscall.sh/
     Clong(241)
 elseif Sys.ARCH === :arm
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/arm/tools/syscall.tbl
     Clong(364)
 elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/powerpc/kernel/syscalls/syscall.tbl
     Clong(319)
 elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
-    # See syscalls table at https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
+    # See also https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
     Clong(241)
 else
     Clong(-1) # sentinel for unknown syscall ID
@@ -343,18 +350,25 @@ function Base.show(io::IO, g::EventGroup)
     print(io, "\t", g.event_types[end], ")")
 end
 
+# To support a new architecture, look for the code corresponding to the `prctl` syscall in
+# https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html
 const SYS_prctl = if Sys.ARCH === :x86_64
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_64.tbl
     Clong(157)
 elseif Sys.ARCH === :i686
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/x86/entry/syscalls/syscall_32.tbl
     Clong(172)
 elseif Sys.ARCH === :aarch64
+    # See also https://arm64.syscall.sh/
     Clong(167)
 elseif Sys.ARCH === :arm
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/arm/tools/syscall.tbl
     Clong(172)
 elseif Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
+    # See also https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/powerpc/kernel/syscalls/syscall.tbl
     Clong(171)
 elseif Sys.ARCH === :riscv64 || Sys.ARCH === :rv64
-    # See syscalls table at https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
+    # See also https://jborza.com/post/2021-05-11-riscv-linux-syscalls/
     Clong(167)
 else
     Clong(-1) # sentinel for unknown syscall ID


### PR DESCRIPTION
Fix #55.

I can confirm tests pass locally:
```
     Testing Running tests...
hardware:
  branch-instructions      user, hypervisor
  branch-misses            user, hypervisor
  cache-misses             user, hypervisor
  cache-references         user, hypervisor
  cpu-cycles               user, hypervisor
  instructions             user, hypervisor
  stalled-cycles-backend   user, hypervisor
  stalled-cycles-frontend  user, hypervisor

software:
  alignment-faults         user, hypervisor
  bpf-output               user, hypervisor
  context-switches         user, hypervisor
  cpu-clock                user, hypervisor
  cpu-migrations           user, hypervisor
  dummy                    user, hypervisor
  emulation-faults         user, hypervisor
  major-faults             user, hypervisor
  minor-faults             user, hypervisor
  page-faults              user, hypervisor
  task-clock               user, hypervisor

cache:
  L1-dcache-load-misses    user, hypervisor
  L1-dcache-loads          user, hypervisor
  L1-dcache-store-misses   user, hypervisor
  L1-dcache-stores         user, hypervisor
  L1-icache-load-misses    user, hypervisor
  L1-icache-loads          user, hypervisor
  LLC-load-misses          user, hypervisor
  LLC-loads                user, hypervisor
  LLC-store-misses         user, hypervisor
  LLC-stores               user, hypervisor
  dTLB-load-misses         user, hypervisor
  dTLB-loads               user, hypervisor
  iTLB-load-misses         user, hypervisor
  iTLB-loads               user, hypervisor
Test Summary: | Pass  Total   Time
LinuxPerf     |   37     37  17.1s
     Testing LinuxPerf tests passed
```

Question: I presume it'd be nicer to add the llvmcall in https://github.com/JuliaPerf/LinuxPerf.jl/blob/e7dfcbd22115828de7d716ecf436a1ca19f71d6d/src/LinuxPerf.jl#L359-L384?